### PR TITLE
fix: use path.posix for better cross OS compat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function build({ entryFile, outputFolder }) {
   // write to output folder
   for (const outputFile of outputFiles) {
     fs.writeFileSync(
-      path.join(outputFolder, outputFile.name),
+      path.posix.join(outputFolder, outputFile.name),
       outputFile.content,
       'utf-8'
     );
@@ -167,7 +167,7 @@ class Module {
 
 // resolving
 function resolveRequest(requester, requestPath) {
-  return path.join(path.dirname(requester), requestPath);
+  return path.posix.join(path.dirname(requester), requestPath);
 }
 
 // bundling
@@ -242,6 +242,6 @@ function trim(str) {
 }
 
 build({
-  entryFile: path.join(__dirname, '../fixture/index.js'),
-  outputFolder: path.join(__dirname, '../output'),
+  entryFile: path.posix.join(__dirname, '../fixture/index.js'),
+  outputFolder: path.posix.join(__dirname, '../output'),
 });


### PR DESCRIPTION
## Summary

The bundler currently crashes on my Windows machine due to OS differences resulting in the generated output to not work as intended:

```
C:\Users\yangshun\developer\tmp\byo-bundler\output\bundle.js:32
    modules[moduleName](exports, require);
                       ^

TypeError: modules[moduleName] is not a function
    at require (C:\Users\yangshun\developer\tmp\byo-bundler\output\bundle.js:32:24)
    at Object.fixture/index.js (C:\Users\yangshun\developer\tmp\byo-bundler\output\bundle.js:1:85)
...
```

See the "Before" section in the Test Plan to see why.

The fix is to use `path.posix` for consistent path handling.

Alternatively, in Node 15, you can just import `const path = require('path/posix')` but since Node 15 is still quite new I think it's better to use the older API.

## Test Plan

### Before

```js
const modules = {"C:\Users\yangshun\developer\tmp\byo-bundler\fixture\index.js": function(exports, require) { const _imported = require("C:\\Users\\yangshun\\developer\\tmp\\byo-bundler\\fixture\\square.js");
const _imported2 = require("C:\\Users\\yangshun\\developer\\tmp\\byo-bundler\\fixture\\circle.js");
exports.PI = 3.141;
console.log('Area of square: ', _imported["default"](5));
console.log('Area of circle', _imported2["default"](5)); },"C:\Users\yangshun\developer\tmp\byo-bundler\fixture\square.js": function(exports, require) { function area(side) {
  return side * side;
}
exports.default = area; },"C:\Users\yangshun\developer\tmp\byo-bundler\fixture\circle.js": function(exports, require) { const _imported = require("C:\\Users\\yangshun\\developer\\tmp\\byo-bundler\\fixture\\index.js");
function area(radius) {
  return _imported["PI"] * radius * radius;
}
exports.default = area; },};
const entry = "C:\Users\yangshun\developer\tmp\byo-bundler\fixture\index.js";
function webpackStart({ modules, entry }) {
  const moduleCache = {};
  const require = moduleName => {
    // if in cache, return the cached version
    if (moduleCache[moduleName]) {
      return moduleCache[moduleName];
    }
    const exports = {};
    // this will prevent infinite "require" loop
    // from circular dependencies
    moduleCache[moduleName] = exports;

    // "require"-ing the module,
    // exported stuff will assigned to "exports"
    modules[moduleName](exports, require);
    return moduleCache[moduleName];
  };

  // start the program
  require(entry);
}
webpackStart({ modules, entry });
```

### After

```js
const modules = {"fixture/index.js": function(exports, require) { const _imported = require("fixture/square.js");
const _imported2 = require("fixture/circle.js");
exports.PI = 3.141;
console.log('Area of square: ', _imported["default"](5));
console.log('Area of circle', _imported2["default"](5)); },"fixture/square.js": function(exports, require) { function area(side) {
  return side * side;
}
exports.default = area; },"fixture/circle.js": function(exports, require) { const _imported = require("fixture/index.js");
function area(radius) {
  return _imported["PI"] * radius * radius;
}
exports.default = area; },};
const entry = "fixture/index.js";
function webpackStart({ modules, entry }) {
  const moduleCache = {};
  const require = moduleName => {
    // if in cache, return the cached version
    if (moduleCache[moduleName]) {
      return moduleCache[moduleName];
    }
    const exports = {};
    // this will prevent infinite "require" loop
    // from circular dependencies
    moduleCache[moduleName] = exports;

    // "require"-ing the module,
    // exported stuff will assigned to "exports"
    modules[moduleName](exports, require);
    return moduleCache[moduleName];
  };

  // start the program
  require(entry);
}
webpackStart({ modules, entry });
```